### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,38 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: '0'
+          fetch-depth: 0
           token: ${{ secrets.TOOLS_BOT_PAK }}
 
-      - name: Get associated PR
-        uses: helaili/github-graphql-action@2.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
-        with:
-          query: .github/queries/asssociated-pr.query.yml
-          outputFile: pr.json
-          owner: asfadmin
-          name: hyp3-water-mask
-          sha: ${{ github.sha }}
-
-      - name: Export PR body
-        id: pr
-        run: |
-          PR_QUERY='.data.repository.commit.associatedPullRequests.edges[0].node.body'
-          PR_BODY=$(jq --raw-output "${PR_QUERY}"  pr.json)
-          echo "::set-output name=body::${PR_BODY}"
-
       - name: Create Release
-        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
         with:
           tag_name: ${{ github.ref }}
           release_name: HyP3 Water Mask ${{ github.ref }}
-          body: ${{ steps.pr.outputs.body }}
-          draft: false
-          prerelease: false
 
       - name: Attempt fast-forward develop from master
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,21 +6,21 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8  flake8-import-order flake8-blind-except flake8-builtins
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8  flake8-import-order flake8-blind-except flake8-builtins
 
-    - name: Lint with flake8
-      run: |
-        flake8 --max-line-length=120 --import-order-style=pycharm --statistics \
-            --application-import-names hyp3_water_mask
+      - name: Lint with flake8
+        run: |
+          flake8 --max-line-length=120 --import-order-style=pycharm --statistics \
+              --application-import-names hyp3_water_mask
 
 
   gitleaks:
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: '0'
+          fetch-depth: 0
 
       - name: Scan for secrets with gitleaks
         uses: zricethezav/gitleaks-action@master
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: '0'
+          fetch-depth: 0
 
       - uses: actions/setup-python@v1
         with:
@@ -53,7 +53,6 @@ jobs:
         run: |
           git fetch origin +refs/tags/*:refs/tags/*
           export LAST_TAG_HASH=$(git show-ref --hash -- $(git describe --abbrev=0))
-          echo -e '.*gitleaks.toml$\n.gitlab-ci.yml' > exclude-patterns.txt
           trufflehog --regex --entropy True --since_commit "${LAST_TAG_HASH}" \
-              --exclude_paths exclude-patterns.txt file://"${PWD}"
+              --exclude_paths .trufflehog.txt file://"${PWD}"
 

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Safety analysis of conda environment
         shell: bash -l {0}
         run: |
-          python -m pip freeze | safety check --full-report --stdin
-          conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report --stdin
+          # Ignore Safety vulerability #38264, GDAL < 3.1, because conda deps resolve to 3.0.4
+          python -m pip freeze | safety check --full-report -i 38264 --stdin
+          conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report -i 38264 --stdin
 
 
   package:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -3,8 +3,8 @@ name: Test and build
 on:
   push:
     branches:
-    - master
-    - develop
+      - master
+      - develop
   pull_request:
     branches:
       - master
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
 
       - uses: goanpeca/setup-miniconda@v1
         with:
@@ -55,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: '0'
+          fetch-depth: 0
           token: ${{ secrets.TOOLS_BOT_PAK }}
 
       - name: Get associated PR
@@ -140,8 +138,6 @@ jobs:
     needs: package
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
 
       - uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -170,7 +166,7 @@ jobs:
       - name: Add test tag
         if: github.ref == 'refs/heads/develop'
         run: |
-          export SDIST_VERSION=${{needs.package.outputs.SDIST_VERSION}}
+          export SDIST_VERSION=${{ needs.package.outputs.SDIST_VERSION }}
           docker tag ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:${SDIST_VERSION/+/_} \
               ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:test
           docker push ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:test
@@ -178,7 +174,7 @@ jobs:
       - name: Add latest tag
         if: github.ref == 'refs/heads/master'
         run: |
-          export SDIST_VERSION=${{needs.package.outputs.SDIST_VERSION}}
+          export SDIST_VERSION=${{ needs.package.outputs.SDIST_VERSION }}
           docker tag ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:${SDIST_VERSION/+/_} \
               ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:latest
           docker push ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:latest

--- a/.trufflehog.txt
+++ b/.trufflehog.txt
@@ -1,0 +1,2 @@
+.*gitleaks.toml$
+.gitlab-ci.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://scm.asf.alaska.edu/hyp3/hyp3-water-mask/compare/v0.0.0...develop) -- likely v0.0.1
+## [Unreleased](https://github.com/asfadmin/hyp3-water-mask/compare/v0.0.0...develop) -- likely v0.0.1
 


### PR DESCRIPTION
Through development of `hyp3-lib` and `hyp3-rtc-gamma` for v2, some tweaks have been made to the workflow. This:

* Simplifies the release workflow
* Fixes some whitespace and types in the workflow yamls
* Moves trufflehog excludes to their own file
* Fixes a link in the changelog
* Ignores Saftey's GDAL warning b/c conda deps resolve to 3.0.4